### PR TITLE
fix(client, data-node): Make create range on data node work

### DIFF
--- a/components/client/src/client.rs
+++ b/components/client/src/client.rs
@@ -378,7 +378,7 @@ mod tests {
         test_util::try_init_log();
         tokio_uring::start(async move {
             #[allow(unused_variables)]
-            let port = 2378;
+            let port = 12378;
             let port = run_listener().await;
             let mut config = config::Configuration::default();
             config.server.host = "localhost".to_owned();
@@ -418,6 +418,33 @@ mod tests {
             let (tx, _rx) = broadcast::channel(1);
             let client = Client::new(config, tx);
             let range = RangeMetadata::new(100, 0, 0, 0, None);
+            client.create_range_replica(&target, range).await
+        })
+    }
+
+    #[test]
+    fn test_create_range_data_node() -> Result<(), ClientError> {
+        test_util::try_init_log();
+        tokio_uring::start(async {
+            #[allow(unused_variables)]
+            let placement_manager_port = 12378;
+            let placement_manager_port = run_listener().await;
+
+            #[allow(unused_variables)]
+            let data_node_port = 10911;
+            let data_node_port = run_listener().await;
+
+            let mut config = config::Configuration::default();
+            config.server.host = "127.0.0.1".to_owned();
+            config.server.port = data_node_port;
+            config.placement_manager = format!("127.0.0.1:{}", placement_manager_port);
+
+            let target = format!("127.0.0.1:{}", data_node_port);
+
+            let config = Arc::new(config);
+            let (tx, _rx) = broadcast::channel(1);
+            let client = Client::new(config, tx);
+            let range = RangeMetadata::new_range(203, 0, 0, 0, None, 1, 1);
             client.create_range_replica(&target, range).await
         })
     }

--- a/components/client/src/composite_session.rs
+++ b/components/client/src/composite_session.rs
@@ -482,6 +482,7 @@ impl CompositeSession {
                 );
                 return Err(ClientError::CreateRange(response.status.code));
             }
+
             if let Some(response::Headers::CreateRange { range }) = response.headers {
                 Ok(range)
             } else {

--- a/components/model/src/range/mod.rs
+++ b/components/model/src/range/mod.rs
@@ -34,11 +34,11 @@ pub struct RangeMetadata {
 
     /// The range replica expected count. When cluster nodes count is less than replica count but
     /// but larger than ack_count, the range can still be successfully created.
-    replica_count: u32,
+    replica_count: u8,
 
     /// The range replica ack count, only success ack >= ack_count, then the write is success.
     /// For seal range, success seal range must seal replica count >= (replica_count - ack_count + 1)
-    ack_count: u32,
+    ack_count: u8,
 }
 
 impl RangeMetadata {
@@ -62,8 +62,8 @@ impl RangeMetadata {
         epoch: u64,
         start: u64,
         end: Option<u64>,
-        replica_count: u32,
-        ack_count: u32,
+        replica_count: u8,
+        ack_count: u8,
     ) -> Self {
         Self {
             stream_id,
@@ -117,11 +117,11 @@ impl RangeMetadata {
         self.end
     }
 
-    pub fn replica_count(&self) -> u32 {
+    pub fn replica_count(&self) -> u8 {
         self.replica_count
     }
 
-    pub fn ack_count(&self) -> u32 {
+    pub fn ack_count(&self) -> u8 {
         self.ack_count
     }
 
@@ -169,6 +169,8 @@ impl From<&RangeMetadata> for RangeT {
         } else {
             range.nodes = Some(replica);
         }
+        range.replica_count = value.replica_count as i8;
+        range.ack_count = value.ack_count as i8;
         range
     }
 }
@@ -191,8 +193,8 @@ impl From<&RangeT> for RangeMetadata {
                 offset => Some(offset as u64),
             },
             replica,
-            replica_count: value.replica_count as u32,
-            ack_count: value.ack_count as u32,
+            replica_count: value.replica_count as u8,
+            ack_count: value.ack_count as u8,
         }
     }
 }

--- a/components/replication/src/stream_manager/replication_range.rs
+++ b/components/replication/src/stream_manager/replication_range.rs
@@ -332,8 +332,8 @@ impl ReplicationRange {
     async fn replicas_seal(
         log_ident: &String,
         replicas: Rc<RefCell<Vec<Rc<Replicator>>>>,
-        replica_count: u32,
-        ack_count: u32,
+        replica_count: u8,
+        ack_count: u8,
         end_offset: Option<u64>,
     ) -> Result<u64, ReplicationError> {
         let end_offsets = Rc::new(RefCell::new(Vec::<u64>::new()));

--- a/data-node/src/error.rs
+++ b/data-node/src/error.rs
@@ -18,7 +18,7 @@ pub enum ServiceError {
     #[error("The range is already sealed")]
     AlreadySealed,
 
-    #[error("The range is already existed")]
+    #[error("The range already existed")]
     AlreadyExisted,
 
     #[error("Resource `{0}` is not found")]

--- a/data-node/src/lib.rs
+++ b/data-node/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(result_option_inspect)]
+#![feature(try_find)]
 
 pub(crate) mod cli;
 pub(crate) mod connection_tracker;


### PR DESCRIPTION
Fix converter between RangeMetadata and RangeT;
The data node create_range handler response now includes original Range metadata.
Creating range on data-node is now idempotent;
Add unit test for create_range on data-node
