### PR TITLE
feat(data-node): Print built info on data-node start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99c4cdc7b2c2364182331055623bdf45254fcb679fea565c40c3c11c101889a"
+dependencies = [
+ "cargo-lock",
+ "chrono",
+ "git2",
+ "semver",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +421,18 @@ dependencies = [
  "shell-escape",
  "termcolor",
  "walkdir",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
+dependencies = [
+ "semver",
+ "serde",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -867,6 +891,7 @@ name = "data-node"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "built",
  "byteorder",
  "bytes",
  "cfg-if",
@@ -1076,6 +1101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1283,19 @@ name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
+name = "git2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -1432,6 +1479,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1668,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2213,6 +2283,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "percentage"
@@ -3219,6 +3295,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,10 +3550,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unsafe-any-ors"
@@ -3478,6 +3584,17 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
 [workspace.dependencies]
 anyhow = "1.0"
 async-channel = "1.8.0"
+built = "0.6"
 byteorder = "1"
 bytes = "1"
 cfg-if = "1.0.0"

--- a/data-node/Cargo.toml
+++ b/data-node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
+built = { workspace = true, features = ["chrono", "semver"] }
 byteorder =  { workspace = true }
 bytes =  { workspace = true }
 cfg-if = { workspace = true }
@@ -48,6 +49,9 @@ tikv-jemallocator = "0.5"
 [dev-dependencies]
 mockall = { workspace = true }
 test-util = { path = "../components/test-util" }
+
+[build-dependencies]
+built = { workspace = true, features = ["git2", "chrono", "semver"] }
 
 [features]
 paranoid = []

--- a/data-node/build.rs
+++ b/data-node/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let mut opts = built::Options::default();
+    opts.set_dependencies(false);
+
+    let src = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let dst = std::path::Path::new(&std::env::var("OUT_DIR").unwrap()).join("built.rs");
+    built::write_built_file_with_opts(&opts, src.as_ref(), &dst)
+        .expect("Failed to acquire build-time information");
+}

--- a/data-node/src/lib.rs
+++ b/data-node/src/lib.rs
@@ -19,6 +19,10 @@ mod metrics;
 pub(crate) mod profiling;
 pub(crate) mod session;
 
+pub mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/data-node/src/main.rs
+++ b/data-node/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     cli.init_log().unwrap();
 
     display_built_info();
-    
+
     let config = match cli.create_config() {
         Ok(config) => config,
         Err(e) => {
@@ -51,7 +51,7 @@ macro_rules! build_info {
 }
 
 /// Display the built information.
-/// 
+///
 /// The build information is additively printed to both stdout and log.
 fn display_built_info() {
     build_info!(

--- a/data-node/src/main.rs
+++ b/data-node/src/main.rs
@@ -11,11 +11,11 @@ use tikv_jemallocator::Jemalloc;
 static GLOBAL: Jemalloc = Jemalloc;
 
 fn main() {
-    print_built_info();
-
     let cli = Cli::parse();
     cli.init_log().unwrap();
 
+    display_built_info();
+    
     let config = match cli.create_config() {
         Ok(config) => config,
         Err(e) => {
@@ -50,8 +50,10 @@ macro_rules! build_info {
     };
 }
 
-/// Prints the built information.
-fn print_built_info() {
+/// Display the built information.
+/// 
+/// The build information is additively printed to both stdout and log.
+fn display_built_info() {
     build_info!(
         "Data-Node v{}, built for {} by {}.",
         data_node::built_info::PKG_VERSION,

--- a/data-node/src/main.rs
+++ b/data-node/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use data_node::Cli;
+use log::info;
 use tokio::sync::broadcast;
 
 #[cfg(not(target_env = "msvc"))]
@@ -41,9 +42,17 @@ fn main() {
     }
 }
 
+// Additively prints the built info to both stdout and log.
+macro_rules! build_info {
+    ($($st:tt)*) => {
+        println!($($st)*);
+        info!($($st)*);
+    };
+}
+
 /// Prints the built information.
 fn print_built_info() {
-    println!(
+    build_info!(
         "data-node {}, built for {} by {}.\n",
         data_node::built_info::PKG_VERSION,
         data_node::built_info::TARGET,
@@ -51,7 +60,7 @@ fn print_built_info() {
     );
 
     let built_time = built::util::strptime(data_node::built_info::BUILT_TIME_UTC);
-    println!(
+    build_info!(
         "Built with profile \"{}\", on {} ({} days ago)",
         data_node::built_info::PROFILE,
         built_time.with_timezone(&built::chrono::offset::Local),
@@ -64,7 +73,7 @@ fn print_built_info() {
         data_node::built_info::GIT_COMMIT_HASH,
         data_node::built_info::GIT_COMMIT_HASH_SHORT,
     ) {
-        print!(
+        build_info!(
             "Built from git `{}`, commit {}, short_commit {}; the working directory was \"{}\".",
             v,
             hash,
@@ -73,9 +82,8 @@ fn print_built_info() {
         );
     }
 
-    match data_node::built_info::GIT_HEAD_REF {
-        Some(r) => println!(" The branch was `{r}`.\n"),
-        None => println!("\n"),
+    if let Some(r) = data_node::built_info::GIT_HEAD_REF {
+        build_info!("The branch was `{r}`");
     }
 }
 

--- a/data-node/src/main.rs
+++ b/data-node/src/main.rs
@@ -53,7 +53,7 @@ macro_rules! build_info {
 /// Prints the built information.
 fn print_built_info() {
     build_info!(
-        "data-node {}, built for {} by {}.\n",
+        "Data-Node v{}, built for {} by {}.",
         data_node::built_info::PKG_VERSION,
         data_node::built_info::TARGET,
         data_node::built_info::RUSTC_VERSION
@@ -61,7 +61,7 @@ fn print_built_info() {
 
     let built_time = built::util::strptime(data_node::built_info::BUILT_TIME_UTC);
     build_info!(
-        "Built with profile \"{}\", on {} ({} days ago)",
+        "Built with profile \"{}\", on {} ({} days ago).",
         data_node::built_info::PROFILE,
         built_time.with_timezone(&built::chrono::offset::Local),
         (built::chrono::offset::Utc::now() - built_time).num_days(),
@@ -83,7 +83,7 @@ fn print_built_info() {
     }
 
     if let Some(r) = data_node::built_info::GIT_HEAD_REF {
-        build_info!("The branch was `{r}`");
+        build_info!("The branch was `{r}`.");
     }
 }
 


### PR DESCRIPTION
Sample console output
```text
data-node 0.1.0, built for x86_64-unknown-linux-gnu by rustc 1.72.0-nightly (fe7454bf4 2023-06-19).
Built with profile "debug", on 2023-06-21 20:28:51 +08:00 (0 days ago)
Built from git `data-node-v0.1.0-36-g5fde2a7`, commit 5fde2a7ba5286aa7eff6271832c2842b073c3809, short_commit 5fde2a7; the working directory was "clean". The branch was `refs/heads/built`.
```